### PR TITLE
make Report API more general and report ms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rocicorp/datadog-util",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rocicorp/datadog-util",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "SEE LICENSE IN https://roci.dev/terms.html",
       "bin": {
         "report-metrics": "out/report-metrics.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rocicorp/datadog-util",
   "description": "Datadog utilities",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "repository": "github:rocicorp/datadog-util",
   "license": "SEE LICENSE IN https://roci.dev/terms.html",
   "main": "out/datadog-utils.js",

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -7,4 +7,6 @@ export {
   DatadogSeries,
   gaugeValue,
   report,
+  DD_DISTRIBUTION_METRIC_URL,
+  DD_AUTH_HEADER_NAME,
 } from './metrics/metrics.js';


### PR DESCRIPTION
Make the report API take a url and list of headers so we can use it to proxy to reflect server on the client or report directly in reflect server.

Also report time in ms, not seconds. 